### PR TITLE
use glom/TI for TI too

### DIFF
--- a/src/components/ExpressionTables/DiffexByCluster.js
+++ b/src/components/ExpressionTables/DiffexByCluster.js
@@ -116,7 +116,7 @@ class DiffexByCluster extends Component {
                     sortable: true,
                     headerTooltip: 'Expression measured against all regions or just Glomerulus vs Tubulo-interstitium.',
                     field: 'segmentName',
-                    valueFormatter: params => params.value === 'Glomerulus / Renal Corpuscle' ? 'to Glom/TI (only)' : 'to all regions'
+                    valueFormatter: params => params.value === 'Glomerulus / Renal Corpuscle' || params.value === 'Tubulo-interstitium' ? 'to Glom/TI (only)' : 'to all regions'
                 }
             );
         }

--- a/src/components/ExpressionTables/DiffexByCluster.js
+++ b/src/components/ExpressionTables/DiffexByCluster.js
@@ -191,7 +191,7 @@ class DiffexByCluster extends Component {
           return results.map(({ gene, segmentName, foldChange, pVal, pValAdj }) => {
           return {
               gene: gene,
-              comparison: segmentName === 'Glomerulus / Renal Corpuscle' ? 'to Glom/TI (only)' : 'to all regions',
+              comparison: segmentName === 'Glomerulus / Renal Corpuscle' || segmentName === 'Tubulo-interstitium' ? 'to Glom/TI (only)' : 'to all regions',
               foldChange: formatNumberToPrecision(foldChange, 3),
               pVal: formatNumberToPrecision(pVal, 3),
               pValAdj: formatNumberToPrecision(pValAdj, 3, true)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected labeling in the comparison column to consistently display "to Glom/TI (only)" for both Glomerulus/Renal Corpuscle and Tubulo-interstitium regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->